### PR TITLE
fix: update test expression to use sqrt without Math prefix

### DIFF
--- a/04-function-calling-tools/code/01-simple-tool.ts
+++ b/04-function-calling-tools/code/01-simple-tool.ts
@@ -49,7 +49,7 @@ async function main() {
   const testExpressions = [
     "25 * 17",
     "(100 + 50) / 2",
-    "Math.sqrt(144)",
+    "sqrt(144)",
   ];
 
   for (const expr of testExpressions) {


### PR DESCRIPTION
Changed "Math.sqrt(144)" to "sqrt(144)" in the testExpressions array to align with the function-calling tool's expected input format, simplifying the expression for better compatibility.

Before
```bash
Expression: Math.sqrt(144)
Result: Error evaluating expression: Undefined symbol Math
```

After
```bash
Expression: sqrt(144)
Result: The result is: 12
```
