### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,7 +13,7 @@ Validates all code examples in the course when explicitly requested. **Does not 
 - Verifies they execute without errors
 - Tests on Node.js 22 (LTS)
 - Automatically provides input for interactive examples
-- Makes 60+ API calls
+- Runs `npm run test:parallel` (120-second timeout per example)
 
 **How to trigger:**
 
@@ -51,13 +51,14 @@ To validate all examples on your local machine:
 # Install dependencies first
 npm install
 
-# Run validation
+# Sequential validation (safer against rate limits)
 npm test
-# or
-npm run validate
+
+# Parallel validation (faster; matches CI)
+npm run test:parallel
 ```
 
-**Note:** You need `AI_API_KEY`, `AI_ENDPOINT`, and `AI_MODEL` environment variables set. See [Course Setup](../../00-course-setup/README.md) for details.
+**Note:** You need `AI_API_KEY`, `AI_ENDPOINT`, `AI_MODEL`, and `AI_EMBEDDING_MODEL` in `.env`. See [Course Setup](../../00-course-setup/README.md) for details.
 
 ## GitHub Actions Secrets Setup
 
@@ -72,10 +73,12 @@ Configure Microsoft Foundry credentials as repository secrets:
 
 ## Validation Details
 
-The validation script:
-- ✅ Finds all `.ts` files in `code/` and `solution/` directories
-- ✅ Executes each file with a 30-second timeout (60s for slow examples)
+The validation scripts (`scripts/validate-examples.ts` and `scripts/validate-examples-parallel.ts`) share config in `scripts/validation-common.ts`:
+- ✅ Finds all `.ts` files in `code/`, `solution/`, and `samples/` directories
+- ✅ Executes each file with a 120-second timeout
 - ✅ Automatically provides input for interactive examples
+- ✅ Starts server examples, checks for a ready message, then stops them
+- ✅ Skips files listed in `SKIP_FILES` (currently `temperature-lab.ts`)
 - ✅ Reports success/failure rates
 - ✅ Exits with error code if any examples fail
 
@@ -86,6 +89,7 @@ These files require user interaction and receive automated input during testing:
 - `streaming-chat.ts` - Receives "Hello\n" as input
 - `qa-program.ts` - Receives "What is 2+2?\n" as input
 - `03-human-in-loop.ts` - Receives "yes\nno\nno\n" as input
+- `conversational-rag.ts` - Receives "What is TypeScript?\n" as input
 
 ### Test Results
 
@@ -99,9 +103,10 @@ After running, you'll see:
 
 When adding new code examples:
 
-1. **Standard examples** - Will be automatically detected and tested
-2. **Interactive examples** - Add filename to `INTERACTIVE_FILES` array in `validate-examples.ts`
-3. **Slow examples** - Add filename to `SLOW_FILES` array for 60s timeout
+1. **Standard examples** - Will be automatically detected and tested (120-second timeout)
+2. **Interactive examples** - Add an entry to `INTERACTIVE_FILES` in `scripts/validation-common.ts`
+3. **Server examples** - Add an entry to `SERVER_FILES` in `scripts/validation-common.ts`
+4. **Skipped examples** - Add to `SKIP_FILES` in `scripts/validation-common.ts` only if the example cannot run on Microsoft Foundry
 
 ## Troubleshooting
 
@@ -120,7 +125,7 @@ When adding new code examples:
 
 ✅ **DO:**
 - Test examples locally before committing
-- Add timeouts for long-running examples
+- Keep examples within the 120-second validation timeout
 - Include error handling in examples
 - Document any special requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Project Overview
 
-This is **LangChain.js for Beginners** - a comprehensive educational course teaching AI application development with LangChain.js and TypeScript. The repository contains 8 sections (00-07) covering everything from basic chat models to autonomous agents, RAG systems, and Model Context Protocol (MCP) integration.
+This is **LangChain.js for Beginners** - a comprehensive educational course teaching AI application development with LangChain.js and TypeScript. The repository contains 9 chapters (00-08) covering everything from basic chat models to autonomous agents, RAG systems, and Model Context Protocol (MCP) integration.
 
-**Architecture**: Educational course structure with 71+ runnable TypeScript examples organized by topic
-**Key Technologies**: LangChain.js, TypeScript, tsx, Node.js >=22.0.0 (LTS), MCP, OpenAI/Microsoft Foundry/Anthropic
+**Architecture**: Educational course structure with 80+ runnable TypeScript examples organized by topic
+**Key Technologies**: LangChain.js, TypeScript, tsx, Node.js >=22.0.0 (LTS), MCP, Microsoft Foundry
 **Purpose**: Teaching developers how to build AI-powered applications using an agent-first philosophy
 **Teaching Approach**: Agent-first (Tools → Agents → Documents → Agentic RAG)
 
@@ -26,9 +26,11 @@ LangChainJS-for-Beginners/
 │       └── mcp-rag-server/      # RAG as an MCP service (capstone example)
 ├── data/                     # Sample data files
 ├── scripts/                  # Build and validation scripts
-│   ├── build-check.ts        # TypeScript compilation validator
-│   ├── test-setup.ts         # Environment setup tester
-│   └── validate-examples.ts  # Code example test runner
+│   ├── build-check.ts                # TypeScript compilation validator
+│   ├── test-setup.ts                 # Environment setup tester
+│   ├── validation-common.ts          # Shared validation config (timeouts, interactive/server/skip lists)
+│   ├── validate-examples.ts          # Sequential example test runner
+│   └── validate-examples-parallel.ts # Parallel example test runner (CI)
 ├── .env.example              # Environment configuration template
 └── GLOSSARY.md               # Comprehensive course glossary
 ```
@@ -94,7 +96,7 @@ When working on course content or examples:
 1. Each chapter is self-contained with its own code examples
 2. Code files use ES modules (`"type": "module"` in package.json)
 3. All examples use environment variables for configuration (never hardcode keys)
-4. Interactive examples should be marked in `validate-examples.ts`
+4. Interactive, server, and skipped examples should be marked in `scripts/validation-common.ts`
 
 ## Testing Instructions
 
@@ -105,51 +107,57 @@ When working on course content or examples:
 npm run build
 ```
 
-This compiles 71 TypeScript files to check for:
+This type-checks all course TypeScript files (currently 80+) for:
 - ✅ Type errors
 - ✅ Syntax errors
 - ✅ Import issues
 - ✅ No API calls - just compilation
 
-### Full Validation (Comprehensive - 20-40 minutes)
+### Full Validation (Comprehensive - 20-40 minutes sequential, ~5 minutes parallel)
 
 ```bash
-# Run all code examples with actual API calls
+# Run all code examples sequentially (avoids rate limiting)
 npm test
+
+# Run all code examples in parallel (faster; used in CI)
+npm run test:parallel
 ```
 
 **Important Notes**:
 - Requires valid `AI_API_KEY`, `AI_ENDPOINT`, `AI_MODEL`, and `AI_EMBEDDING_MODEL` in `.env`
-- Tests all examples sequentially to avoid rate limiting
+- Sequential `npm test` is safer against rate limits; CI uses `npm run test:parallel`
 - Interactive files are tested with automated input
-- Some examples have 60-second timeouts (marked in `SLOW_FILES`)
+- All examples use a 120-second timeout (`TIMEOUT_MS` in `scripts/validation-common.ts`)
 - Examples in `future/` folder are not included in validation
 
 ### Testing Specific Examples
 
 ```bash
 # Run a single example
-npx tsx 03-prompt-templates/code/01-basic-template.ts
+npx tsx 03-prompts-messages-outputs/code/03-basic-template.ts
 
 # Test a specific chapter
-npx tsx 06-rag-systems/code/*.ts
+npx tsx 08-agentic-rag-systems/code/*.ts
 ```
 
 ### Test File Categories
+
+Configured in `scripts/validation-common.ts`:
 
 **Interactive Files** (tested with automated input):
 - `chatbot.ts`
 - `streaming-chat.ts`
 - `qa-program.ts`
 - `03-human-in-loop.ts`
+- `conversational-rag.ts`
 
-**Slow Files** (60-second timeout):
-- `03-model-comparison.ts` - Compares multiple models
-- `03-parameters.ts` - Tests 9 parameter combinations
-- `temperature-lab.ts` - Temperature experiments
-- `04-error-handling.ts` - Error scenarios
-- `robust-chat.ts` - Retry logic testing
-- And others listed in `validate-examples.ts`
+**Server Files** (started, checked for a ready message, then stopped):
+- `basic-mcp-server.ts`
+- `mcp-rag-server.ts`
+- `stdio-calculator-server.ts`
+
+**Skipped Files** (`SKIP_FILES`):
+- `temperature-lab.ts` - Uses `temperature=0`, which some Microsoft Foundry models reject
 
 ## Code Style
 
@@ -224,26 +232,30 @@ npm run build
 
 ### Validation Process
 
-The repository uses `scripts/validate-examples.ts` for comprehensive testing:
+The repository uses `scripts/validate-examples.ts` (sequential) and `scripts/validate-examples-parallel.ts` (CI):
 
 ```bash
-# Full validation (runs all examples)
+# Full validation (runs all examples sequentially)
 npm test
+
+# Parallel validation (faster; used in GitHub Actions)
+npm run test:parallel
 ```
 
 **Process**:
-1. Finds all `.ts` files in `code/` and `solution/` directories
-2. Runs each file sequentially with `tsx`
+1. Finds all `.ts` files in `code/`, `solution/`, and `samples/` directories
+2. Runs each file with `tsx` (120-second timeout)
 3. Provides automated input for interactive examples
-4. Reports success/failure with detailed error messages
-5. Exits with error code 1 if any examples fail
+4. Starts server examples, checks for a ready message, then stops them
+5. Reports success/failure with detailed error messages
+6. Exits with error code 1 if any examples fail
 
 ### CI/CD Pipeline
 
 GitHub Actions workflow (`.github/workflows/validate-examples.yml`):
 - **Triggers**: Only runs when commit message or PR title contains "validate-examples", or manually triggered
 - Tests on Node.js 22 (LTS)
-- Runs full validation suite
+- Runs `npm run test:parallel`
 - Uses secrets: `AI_API_KEY`, `AI_ENDPOINT`, `AI_MODEL`, `AI_EMBEDDING_MODEL`
 - Timeout: 30 minutes
 
@@ -266,25 +278,20 @@ git commit -m "Update RAG examples validate-examples"
 3. Follow existing patterns for imports and structure
 4. Test locally: `npx tsx path/to/05-new-example.ts`
 5. Run build check: `npm run build`
-6. No changes to `validate-examples.ts` needed
+6. No changes to `scripts/validation-common.ts` needed
 
-### Slow Example (Multiple API calls or >30 seconds)
+### Slow Example (Multiple API calls)
 
 1. Create the example file as above
-2. Add filename to `SLOW_FILES` array in `validate-examples.ts`:
-```typescript
-const SLOW_FILES = [
-  "03-model-comparison.ts",
-  "your-new-slow-file.ts", // Add here
-];
-```
+2. All examples already have a 120-second timeout — no extra list is required
+3. If an example cannot run against Microsoft Foundry (API limitation), add it to `SKIP_FILES` in `scripts/validation-common.ts`
 
 ### Interactive Example (Requires user input)
 
 1. Create the example file
-2. Add to `INTERACTIVE_FILES` array in `validate-examples.ts`:
+2. Add to `INTERACTIVE_FILES` in `scripts/validation-common.ts`:
 ```typescript
-const INTERACTIVE_FILES = [
+export const INTERACTIVE_FILES = [
   { file: "chatbot.ts", input: "Hello\n" },
   { file: "your-new-interactive.ts", input: "test input\n" },
 ];
@@ -318,7 +325,7 @@ npm test
 
 - All TypeScript files must compile (`npm run build` passes)
 - Changed examples must run successfully
-- Update `validate-examples.ts` if adding interactive/slow files
+- Update `scripts/validation-common.ts` if adding interactive, server, or skipped files
 - Update chapter README.md if adding new concepts
 - Include comments in code for educational clarity
 
@@ -343,9 +350,9 @@ const apiKey = process.env.AI_API_KEY;
 
 ### Rate Limiting
 
-- Validation script runs examples sequentially to avoid rate limits
-- Interactive examples timeout after 30-60 seconds
-- Consider rate limits when adding multiple API calls
+- Sequential validation (`npm test`) runs examples one at a time to avoid rate limits
+- All examples timeout after 120 seconds
+- Consider rate limits when adding multiple API calls or using `npm run test:parallel`
 
 ## Troubleshooting
 
@@ -361,8 +368,9 @@ AI_EMBEDDING_MODEL=text-embedding-3-small
 
 ### "Command timed out"
 
-- Add file to `SLOW_FILES` in `validate-examples.ts`
-- Check for infinite loops or hanging API calls
+- All examples already have a 120-second timeout
+- Check for infinite loops, hanging API calls, or too many sequential model requests
+- If the example cannot run on Microsoft Foundry, add it to `SKIP_FILES` in `scripts/validation-common.ts`
 
 ### "Module not found"
 
@@ -441,7 +449,7 @@ npx tsx 08-agentic-rag-systems/samples/mcp-rag-server/mcp-rag-agent.ts
 
 - Start with `00-course-setup` for environment configuration
 - Each chapter has learning objectives in its README.md
-- Follow the agent-first progression (Chapters 4 → 5 → 6 → 7)
+- Follow the agent-first progression (Chapters 4 → 5 → 6 → 7 → 8)
 - Try the assignments before looking at solutions
 - Examples in `code/` directory demonstrate concepts
 - Solutions in `solution/` directory show complete implementations
@@ -476,7 +484,8 @@ npm run dev <file>            # Watch mode
 
 # Testing
 npm run build                 # Type-check (fast)
-npm test                      # Full validation (slow)
+npm test                      # Full validation (sequential)
+npm run test:parallel         # Full validation (parallel / CI)
 npx tsx <file>                # Run individual file
 
 # Trigger CI/CD validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,22 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@langchain/anthropic": "^1.3.26",
-        "@langchain/classic": "^1.0.34",
-        "@langchain/core": "^1.1.48",
-        "@langchain/mcp-adapters": "^1.1.3",
-        "@langchain/openai": "^1.4.7",
+        "@langchain/anthropic": "^1.5.8",
+        "@langchain/classic": "^1.0.45",
+        "@langchain/core": "^1.2.9",
+        "@langchain/mcp-adapters": "^1.1.4",
+        "@langchain/openai": "^1.5.10",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
-        "langchain": "^1.4.2",
+        "langchain": "^1.5.10",
         "mathjs": "^15.2.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
-        "@types/node": "^25.5.2",
-        "prettier": "^3.8.1",
-        "tsx": "^4.21.0",
+        "@types/node": "^25.9.5",
+        "prettier": "^3.9.6",
+        "tsx": "^4.23.12",
         "typescript": "^6.0.2"
       },
       "engines": {
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.95.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.2.tgz",
-      "integrity": "sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -510,46 +510,46 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@langchain/anthropic": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.4.0.tgz",
-      "integrity": "sha512-rs1yVydrHjyiD31uChdCnKZpmDuKa0Bpz8Raiy9GvqnqmfXPMe0oOrap/2paE+NRSinDbtax8mMpP/yv8EbO1A==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.5.8.tgz",
+      "integrity": "sha512-KZWgIf+04M9XZHhgH1rVJkqw/C26DM4a4jKk4Qc4HaSbRawN2Dw5nDffna+IoaU/50ohTdyB3HOz9g8XFQYF2A==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.95.1",
+        "@anthropic-ai/sdk": "^0.115.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.47"
+        "@langchain/core": "^1.2.9"
       }
     },
     "node_modules/@langchain/classic": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.34.tgz",
-      "integrity": "sha512-4VG+3QRFBDwYWW4UdVDsbUoeaeTo0XED7wYkeZDc4wa3ZlP4r6GJ/KZlQfHq2AS+CxjW8OQZw2ha6tESesjawQ==",
+      "version": "1.0.45",
+      "resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.45.tgz",
+      "integrity": "sha512-VIC+lJRFejU2el7q4/aibTIk1ccPX0HZGSKhmrkHexZWXpwsjdBBTZYBzUxsgJ3srXAvD3ltLe8ZpbY/isB7rg==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/openai": "1.4.7",
+        "@langchain/openai": "1.5.10",
         "@langchain/textsplitters": "1.0.1",
         "handlebars": "^4.7.9",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.2.2",
         "jsonpointer": "^5.0.1",
         "openapi-types": "^12.1.3",
-        "yaml": "^2.8.3",
+        "yaml": "^2.9.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -559,7 +559,7 @@
         "langsmith": ">=0.4.0 <1.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.48",
+        "@langchain/core": "^1.2.9",
         "cheerio": "*",
         "peggy": "^5.1.0",
         "typeorm": "*"
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.48",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.48.tgz",
-      "integrity": "sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.9.tgz",
+      "integrity": "sha512-conzSEj9Zu1AyXJLXsSbgrtxtxinmI1yGqQ5CIJZSoV5rvv+yvQE/vgBnoySpBQ/bl3YPgj2FL/gbDjWykLSfg==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -595,60 +595,49 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.12.tgz",
+      "integrity": "sha512-63iH/igH5Fh5fHqmWp09YYWaDKKB9v4RCmYNJBrnQ224rFRbjebgyYW6o5RCczN5FZxIhQj+xT51rrNmG0zi5A==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.2",
-        "@langchain/langgraph-sdk": "~1.9.4",
-        "@langchain/protocol": "^0.0.15",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "@langchain/langgraph-checkpoint": "^1.1.5",
+        "@langchain/langgraph-sdk": "~1.9.30",
+        "@langchain/protocol": "^0.0.18",
+        "@standard-schema/spec": "1.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
-        "zod": "^3.25.32 || ^4.2.0",
-        "zod-to-json-schema": "^3.x"
-      },
-      "peerDependenciesMeta": {
-        "zod-to-json-schema": {
-          "optional": true
-        }
+        "@langchain/core": "^1.1.48",
+        "zod": "^3.25.32 || ^4.2.0"
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.3.tgz",
-      "integrity": "sha512-lzamDsWxD/25zIVeEO7Xv38Rq1BCZUQYWx0V6zewHf4LpjzzyxB5N9aZcwdsl+SvHRJASGCnvLleqD9dp3afxg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
+      "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^10.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44"
+        "@langchain/core": "^1.1.48"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.10.tgz",
-      "integrity": "sha512-hsvRVAUR2miafkLpl6HjwYkciKxMk4IZdCJz7fO7wzL344RvIBfbNLeXfcPCKF4VP/pR90723M8Am1olW5xvHQ==",
+      "version": "1.9.31",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.31.tgz",
+      "integrity": "sha512-y1sSdq39IPb6mOX43+JiSezVbUdA8EBEJ1gvn91GP0jrLG0EcSApeRDCjRouyDpPXZ51bQXEQhA8CiHM0mzcAw==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/protocol": "^0.0.16",
+        "@langchain/protocol": "^0.0.18",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
-        "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "p-retry": "^7.1.1"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
@@ -669,12 +658,6 @@
         }
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/@langchain/protocol": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
-      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
-      "license": "MIT"
-    },
     "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -682,9 +665,9 @@
       "license": "MIT"
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -709,26 +692,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/@langchain/mcp-adapters": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.3.tgz",
-      "integrity": "sha512-OPHIQNkTUJjnRj1pr+cp2nguMBZeF3Q1pVT1hCbgU7BrHgV7lov99wbU8po8Cm4zZzmeRtVO/T9X1SrDD1ogtQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@langchain/mcp-adapters/-/mcp-adapters-1.1.4.tgz",
+      "integrity": "sha512-6E8ULWoI9w+lxydeb8yHILyEluonZ4JS42OwSLL1k/RvG/trjGuLYm7P9gE+/pFOxLuNk9wHZ7BLfGju4tcJEQ==",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "debug": "^4.4.3",
         "zod": "^3.25.76 || ^4"
       },
@@ -740,7 +710,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.0.0",
-        "@langchain/langgraph": "^1.0.0"
+        "@langchain/langgraph": "^1.4.10"
       },
       "peerDependenciesMeta": {
         "@langchain/core": {
@@ -752,26 +722,26 @@
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.7.tgz",
-      "integrity": "sha512-i1YLV4pWbGC6W8m0ZNpLObJuf1nyU4o8aWyX4AF9fHn7eM67HfIJWQ5n5XzcCpuSa41otrxA9jvH5XRKwI1qDA==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.10.tgz",
+      "integrity": "sha512-4cxdgolkkXwnAiGEkNrue+ba7jUKjfBwleLCX5DrRVcRGrCc4w5EceblYZOIaHMY6+nhwMqIOtSzBWgcBCLfmw==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
-        "openai": "^6.37.0",
+        "openai": "^7.5.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.48"
+        "@langchain/core": "^1.2.9"
       }
     },
     "node_modules/@langchain/protocol": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
+      "integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
       "license": "MIT"
     },
     "node_modules/@langchain/textsplitters": {
@@ -790,12 +760,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -901,9 +871,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1348,9 +1318,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -1400,11 +1370,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -1437,9 +1408,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1623,9 +1594,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1674,9 +1645,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1722,9 +1693,9 @@
       "license": "MIT"
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1740,15 +1711,25 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-schema-to-ts": {
@@ -1786,13 +1767,13 @@
       }
     },
     "node_modules/langchain": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.4.2.tgz",
-      "integrity": "sha512-SLGipy0r4nqQD0aiUOBYLMeGFfB/QiYnMndfZ8sGN89vXDCIXbYqcE7G/4QDDX3nZsM7/emQpoScmlxEX6sDnQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.5.10.tgz",
+      "integrity": "sha512-JaC12C1qyGn985vvjttr4hr8lfFzWhrXp2M1byZJGmNJ2RiIgqnhiYDuLlG/xHDxhKD3onJ5pCuUif/cbdqPhA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph": "^1.3.2",
-        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph": "^1.4.10",
+        "@langchain/langgraph-checkpoint": "^1.1.5",
         "langsmith": ">=0.5.0 <1.0.0",
         "zod": "^3.25.76 || ^4"
       },
@@ -1800,7 +1781,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.48"
+        "@langchain/core": "^1.2.9"
       }
     },
     "node_modules/langsmith": {
@@ -1996,18 +1977,30 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.39.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.1.tgz",
-      "integrity": "sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.5.0.tgz",
+      "integrity": "sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
+      "engines": {
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },
@@ -2112,9 +2105,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2410,9 +2403,9 @@
       "license": "MIT"
     },
     "node_modules/tsx": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
-      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2509,20 +2502,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -29,22 +29,22 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@langchain/anthropic": "^1.3.26",
-    "@langchain/classic": "^1.0.34",
-    "@langchain/core": "^1.1.48",
-    "@langchain/mcp-adapters": "^1.1.3",
-    "@langchain/openai": "^1.4.7",
+    "@langchain/anthropic": "^1.5.8",
+    "@langchain/classic": "^1.0.45",
+    "@langchain/core": "^1.2.9",
+    "@langchain/mcp-adapters": "^1.1.4",
+    "@langchain/openai": "^1.5.10",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
-    "langchain": "^1.4.2",
+    "langchain": "^1.5.10",
     "mathjs": "^15.2.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "@types/node": "^25.5.2",
-    "prettier": "^3.8.1",
-    "tsx": "^4.21.0",
+    "@types/node": "^25.9.5",
+    "prettier": "^3.9.6",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.2"
   }
 }


### PR DESCRIPTION
- Updated @langchain/anthropic from ^1.3.26 to ^1.5.8
- Updated @langchain/classic from ^1.0.34 to ^1.0.45
- Updated @langchain/core from ^1.1.48 to ^1.2.9
- Updated @langchain/mcp-adapters from ^1.1.3 to ^1.1.4
- Updated @langchain/openai from ^1.4.7 to ^1.5.10
- Updated langchain from ^1.4.2 to ^1.5.10
- Updated @types/node from ^25.5.2 to ^25.9.5
- Updated prettier from ^3.8.1 to ^3.9.6
- Updated tsx from ^4.21.0 to ^4.23.12